### PR TITLE
Replace path separators with division slashes (U+2215) in clock.yaml

### DIFF
--- a/src/commands/clock.yaml
+++ b/src/commands/clock.yaml
@@ -67,7 +67,7 @@ text:
   # Manual Date Input
   - platform: template
     id: manual_date
-    name: "Date (DD⁄MM⁄YY)"
+    name: "Date (DD∕MM∕YY)"
     icon: "mdi:calendar-edit"
     disabled_by_default: true
     optimistic: true
@@ -118,7 +118,7 @@ switch:
   # Automatic / Manual Time Set
   - platform: template
     id: auto_timeset
-    name: "Auto Date⁄Time set"
+    name: "Auto Date∕Time set"
     icon: "mdi:calendar-sync"
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON

--- a/src/commands/clock.yaml
+++ b/src/commands/clock.yaml
@@ -67,7 +67,7 @@ text:
   # Manual Date Input
   - platform: template
     id: manual_date
-    name: "Date (DD/MM/YY)"
+    name: "Date (DD⁄MM⁄YY)"
     icon: "mdi:calendar-edit"
     disabled_by_default: true
     optimistic: true
@@ -118,7 +118,7 @@ switch:
   # Automatic / Manual Time Set
   - platform: template
     id: auto_timeset
-    name: "Auto Date/Time set"
+    name: "Auto Date⁄Time set"
     icon: "mdi:calendar-sync"
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON


### PR DESCRIPTION
Since ESPHome 2026.1.0 usage of path separators in names has been deprecated, and will be completely removed in 2026.7.0 (https://esphome.io/changelog/2026.1.0/:
"Important restrictions:

    Names may not include / because it is reserved as a URL path separator
    Names used in URLs are limited to 120 characters
"

This was causing the following warnings: 
```
WARNING 'Date (DD/MM/YY)' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Date (DD⁄MM⁄YY)' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
WARNING 'Auto Date/Time set' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Auto Date⁄Time set' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.
```

I replaced the slashes with division slashes instead of fraction slashes though, as **ruamel** was having issues determining the proper charmap.
