### PR TITLE
Feature: implement show_slot, shows the specified slot on the device

### DIFF
--- a/src/commands/clock.yaml
+++ b/src/commands/clock.yaml
@@ -67,7 +67,7 @@ text:
   # Manual Date Input
   - platform: template
     id: manual_date
-    name: "Date (DD⁄MM⁄YY)"
+    name: "Date (DD∕MM∕YY)"
     icon: "mdi:calendar-edit"
     disabled_by_default: true
     optimistic: true
@@ -118,7 +118,7 @@ switch:
   # Automatic / Manual Time Set
   - platform: template
     id: auto_timeset
-    name: "Auto Date⁄Time set"
+    name: "Auto Date∕Time set"
     icon: "mdi:calendar-sync"
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON

--- a/src/commands/clock.yaml
+++ b/src/commands/clock.yaml
@@ -67,7 +67,7 @@ text:
   # Manual Date Input
   - platform: template
     id: manual_date
-    name: "Date (DD/MM/YY)"
+    name: "Date (DD⁄MM⁄YY)"
     icon: "mdi:calendar-edit"
     disabled_by_default: true
     optimistic: true
@@ -118,7 +118,7 @@ switch:
   # Automatic / Manual Time Set
   - platform: template
     id: auto_timeset
-    name: "Auto Date/Time set"
+    name: "Auto Date⁄Time set"
     icon: "mdi:calendar-sync"
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON

--- a/src/commands/show_slot.yaml
+++ b/src/commands/show_slot.yaml
@@ -1,0 +1,20 @@
+number:
+  # Show a saved slot
+  - platform: template
+    name: "Show slot"
+    id: show_slot
+    icon: "mdi:movie-open-outline"
+    optimistic: true
+    min_value: 1
+    max_value: 10
+    initial_value: 1
+    step: 1
+    on_value:
+      - ble_client.ble_write:
+          id: ble_matrix
+          service_uuid: '00FA'
+          characteristic_uuid: '0000FA02-0000-1000-8000-00805F9B34FB'
+          value: !lambda |-
+            uint8_t b = (uint8_t) round(x);
+            std::vector<uint8_t> command = {0x07, 0x00, 0x08, 0x80, 0x01, 0x00, b & 0xFF};
+            return command;


### PR DESCRIPTION
This PR implements the show_slot command, which shows the specified slot on the device.
See: https://lucagoc.github.io/pypixelcolor/main/commands/data/

I needed this feature myself as I wanted to display different animations triggered by my assistant. 

Currently I am simply using pypixelcolor from CLI in order to occupy the slots.
